### PR TITLE
feat: add AllowDiskUse support

### DIFF
--- a/src/main/java/com/dbschema/MongoPreparedStatement.java
+++ b/src/main/java/com/dbschema/MongoPreparedStatement.java
@@ -176,7 +176,9 @@ public class MongoPreparedStatement implements PreparedStatement {
             if ( value.isHostObject() ) {
                 obj = value.asHostObject();
             }
-            if (obj instanceof Iterable) {
+            if (obj instanceof AggregateIterable) {
+                lastResultSet = new ResultSetIterator(((AggregateIterable) obj).allowDiskUse(true).iterator(), connection.client.expandResultSet);
+            } else if (obj instanceof Iterable) {
                 lastResultSet = new ResultSetIterator(((Iterable) obj).iterator(), connection.client.expandResultSet);
             } else if (obj instanceof Iterator) {
                 lastResultSet = new ResultSetIterator((Iterator) obj, connection.client.expandResultSet);


### PR DESCRIPTION
set allowDiskUse to true for aggregate operation,
fix: Exceeded memory limit for $group, but didn’t allow external sort. Pass allowDiskUse: true to opt-in