### PR TITLE
revise the uri databasename, not default admin

### DIFF
--- a/src/main/java/com/dbschema/wrappers/WrappedMongoClient.java
+++ b/src/main/java/com/dbschema/wrappers/WrappedMongoClient.java
@@ -30,8 +30,9 @@ public class WrappedMongoClient {
     public enum PingStatus{ INIT, SUCCEED, FAILED, TIMEOUT }
 
     public WrappedMongoClient(String uri, final Properties prop, final ScanStrategy scanStrategy, boolean expandResultSet ){
-        mongoClient = MongoClients.create(uri);
-        this.databaseName = null;
+        int i = uri.lastIndexOf("/")
+        mongoClient = MongoClients.create(uri.substring(0,i));
+        this.databaseName = uri.substring(i+1);
         this.uri = uri;
         this.expandResultSet = expandResultSet;
         this.scanStrategy = scanStrategy;


### PR DESCRIPTION
The bug is only use the "admin"  databases, when i use the driver in logstash jdbc input plugin.

The database in the uri doesn't work，so I revise the code。

uri divided into two parts： mongodb URL and databasename