### PR TITLE
Fix update count to work with Solr DIH handler

### DIFF
--- a/src/main/java/com/wisecoders/dbschema/mongodb/MongoPreparedStatement.java
+++ b/src/main/java/com/wisecoders/dbschema/mongodb/MongoPreparedStatement.java
@@ -411,7 +411,7 @@ public class MongoPreparedStatement implements PreparedStatement {
     @Override
     public int getUpdateCount() throws SQLException	{
         checkClosed();
-        return 0;
+        return -1;
     }
 
     @Override


### PR DESCRIPTION
The driver is able to pull data from MongoDB and push to Solr using Solr's DIH handler. However, the process never terminates, and setting the update count to -1 makes that work.