### PR TITLE
Add ability to publish to maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
 }
 plugins{
     id "java"
+    id 'maven-publish'
 }
 apply plugin: 'application'
 apply plugin: 'distribution'
@@ -46,6 +47,18 @@ jar {
         attributes 'Implementation-Vendor-Id': "dbschema.com"
         attributes 'Implementation-Vendor': "Wise Coders"
         attributes 'Implementation-Version': new Date().format( 'yyMMdd' )
+    }
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = 'com.wisecoders.dbschema'
+            artifactId = 'mongodb-jdbc-driver'
+            version = '1.0.0'
+
+            from components.java
+        }
     }
 }
 


### PR DESCRIPTION
I’ve added the ability to publish as a maven artifact to make it easier to integrate the library.

I have allocated what I thought are reasonable values for the group and artifact. The version is a bit more controversial, I chose "1.0.0" however this might not be the desired version of the code. Also, this version should be linked to a Git tag/release.

Eventually it would be good to have the artifact published to Maven Central, which would make integration easier for everyone.
