### PR TITLE
Expose catalogs in table definitions in metadata

### DIFF
--- a/src/main/java/com/wisecoders/dbschema/mongodb/MongoDatabaseMetaData.java
+++ b/src/main/java/com/wisecoders/dbschema/mongodb/MongoDatabaseMetaData.java
@@ -874,7 +874,7 @@ public class MongoDatabaseMetaData implements DatabaseMetaData
      */
     public boolean supportsCatalogsInTableDefinitions() throws SQLException
     {
-        return false;
+        return true;
     }
 
     public boolean supportsCatalogsInIndexDefinitions() throws SQLException


### PR DESCRIPTION
When SchemaCrawler tries to access the MongoDB database, it will try to determine whether the database supports catalogs and schemas in table names based on the metadata from JDBC connection. If neither is supported (current behaviour), the database schema won't be retrieved.

This change exposes a value signalling SchemaCrawler (or any other consumer) that catalog component (which would be the collection name) is available as part of the table (collection) name, allowing consumers to scan database definitions.